### PR TITLE
Add multi-platform Docker build support for `linux/amd64` and `linux/arm64` architectures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,25 @@ jobs:
       with:
         node-version: '20'
     
+    - name: Install xmllint
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libxml2-utils
+    
     - name: Cache Maven dependencies
       uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
+    
+    - name: Set up QEMU
+      if: github.event.inputs.dry_run != 'true'
+      uses: docker/setup-qemu-action@v3
+    
+    - name: Set up Docker Buildx
+      if: github.event.inputs.dry_run != 'true'
+      uses: docker/setup-buildx-action@v3
     
     - name: Log in to Docker Hub
       if: github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true'
@@ -121,28 +134,25 @@ jobs:
         TAG="${{ steps.calculate_version.outputs.version }}"
         git tag -a "$TAG" -m "Release $TAG"
     
-    - name: Build base image
+    - name: Build and push base image
       if: github.event.inputs.dry_run != 'true'
       run: |
         VERSION="${{ steps.extract_version.outputs.version || steps.calculate_version.outputs.version }}"
-        ./scripts/docker/build-base.sh "$VERSION"
+        ./scripts/docker/build-base.sh "$VERSION" --push
     
-    - name: Build product image
+    - name: Build product JAR
+      if: github.event.inputs.dry_run != 'true'
+      run: |
+        cd src/mcpagent
+        ./mvnw -q -DskipTests package || mvn -q -DskipTests package
+    
+    - name: Build and push product image
       if: github.event.inputs.dry_run != 'true'
       run: |
         VERSION="${{ steps.extract_version.outputs.version || steps.calculate_version.outputs.version }}"
-        ./scripts/docker/build-product.sh "$VERSION"
-    
-    - name: Push images to registry
-      if: github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true'
-      run: |
-        VERSION="${{ steps.extract_version.outputs.version || steps.calculate_version.outputs.version }}"
-        # Push base image
-        docker push admingentoro/gentoro:base-$VERSION
-        docker push admingentoro/gentoro:base-latest
-        # Push product image
-        docker push admingentoro/gentoro:$VERSION
-        docker push admingentoro/gentoro:latest
+        POM_VERSION=$(xmllint --xpath "/*[local-name()='project']/*[local-name()='version']/text()" src/mcpagent/pom.xml)
+        JAR_NAME="mcpagent-$POM_VERSION.jar"
+        ./scripts/docker/build-product.sh "$VERSION" "$JAR_NAME" --push
     
     - name: Push changes for manual release
       if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true'

--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ java -jar target/mcpagent-0.1.0-SNAPSHOT.jar --process=test_suite
 java -jar target/mcpagent-0.1.0-SNAPSHOT.jar --process=mock-server --tcp-port=8082
 ```
 
+## Docker
+
+Docker images are available for multiple platforms (amd64, arm64):
+
+```bash
+# Pull and run the latest image
+docker pull admingentoro/gentoro:latest
+docker run -p 8080:8080 -e OPENAI_API_KEY=your-key admingentoro/gentoro:latest
+
+# Build locally
+./scripts/docker/build-base.sh latest
+./scripts/docker/build-product.sh latest
+```
+
+See [docs/DOCKER_MULTIPLATFORM.md](docs/DOCKER_MULTIPLATFORM.md) for detailed multi-platform build instructions.
+
 ## Environment
 
 - `OPENAI_API_KEY`, `GEMINI_API_KEY`, `ANTHROPIC_API_KEY`

--- a/scripts/docker/build-base.sh
+++ b/scripts/docker/build-base.sh
@@ -2,8 +2,12 @@
 set -euo pipefail
 
 VERSION="${1:-latest}"
+PUSH_FLAG="${2:-}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DOCKERFILE="$ROOT_DIR/Dockerfile.base"
+
+# Default platforms for multi-arch builds
+PLATFORMS="${DOCKER_PLATFORMS:-linux/amd64,linux/arm64}"
 
 # Validate Dockerfile exists
 if [[ ! -f "$DOCKERFILE" ]]; then
@@ -13,11 +17,37 @@ fi
 
 echo "Building base image with version: $VERSION"
 echo "Dockerfile: $DOCKERFILE"
+echo "Platforms: $PLATFORMS"
+
+# Determine build command based on whether we're pushing
+BUILD_CMD="docker buildx build"
+BUILD_ARGS=(
+  -f "$DOCKERFILE"
+  --platform "$PLATFORMS"
+  -t "admingentoro/gentoro:base-$VERSION"
+  -t "admingentoro/gentoro:base-latest"
+)
+
+if [[ "$PUSH_FLAG" == "--push" ]]; then
+  echo "Will push images to registry"
+  BUILD_ARGS+=(--push)
+else
+  echo "Building for local use (load to docker)"
+  # For local builds, we can only load one platform
+  PLATFORMS="linux/amd64"
+  BUILD_ARGS=(
+    -f "$DOCKERFILE"
+    --platform "$PLATFORMS"
+    -t "admingentoro/gentoro:base-$VERSION"
+    -t "admingentoro/gentoro:base-latest"
+    --load
+  )
+fi
 
 # Build Docker image
-if ! docker build -f "$DOCKERFILE" -t "admingentoro/gentoro:base-$VERSION" -t "admingentoro/gentoro:base-latest" "$ROOT_DIR"; then
+if ! $BUILD_CMD "${BUILD_ARGS[@]}" "$ROOT_DIR"; then
   echo "Failed to build base image"
   exit 1
 fi
 
-echo "Successfully built admingentoro/gentoro:base-$VERSION"
+echo "Successfully built admingentoro/gentoro:base-$VERSION for platforms: $PLATFORMS"

--- a/scripts/docker/build-product.ps1
+++ b/scripts/docker/build-product.ps1
@@ -1,20 +1,84 @@
-Param([string]$Version="dev")
+Param(
+    [string]$Version="dev",
+    [string]$JarName="",
+    [switch]$Push
+)
+
+$ErrorActionPreference = "Stop"
+
 $ROOT = (Resolve-Path "$PSScriptRoot\..\..").Path
 $POM = "$ROOT\src\mcpagent\pom.xml"
 
-# Get version from POM
-[xml]$xml = Get-Content $POM
-$pomVersion = $xml.project.version
-$jarName = "mcpagent-$pomVersion.jar"
+# Default platforms for multi-arch builds
+$Platforms = if ($env:DOCKER_PLATFORMS) { $env:DOCKER_PLATFORMS } else { "linux/amd64,linux/arm64" }
 
-# Build app JAR
-Push-Location "$ROOT\src\mcpagent"
-if (Test-Path .\mvnw) { 
-    ./mvnw -q -DskipTests package 
-} else { 
-    mvn -q -DskipTests package 
+# Get version from POM if JarName not provided
+if ([string]::IsNullOrEmpty($JarName)) {
+    [xml]$xml = Get-Content $POM
+    $pomVersion = $xml.project.version
+    $JarName = "mcpagent-$pomVersion.jar"
+    
+    # Build app JAR if not already built
+    Write-Host "Building application JAR..."
+    Push-Location "$ROOT\src\mcpagent"
+    if (Test-Path .\mvnw) { 
+        ./mvnw -q -DskipTests package 
+    } else { 
+        mvn -q -DskipTests package 
+    }
+    Pop-Location
 }
-Pop-Location
+
+# Validate JAR exists
+$jarPath = "$ROOT\src\mcpagent\target\$JarName"
+if (-not (Test-Path $jarPath)) {
+    Write-Error "JAR file not found: $jarPath"
+    exit 1
+}
+
+Write-Host "Building product image with version: $Version"
+Write-Host "JAR: $JarName"
+Write-Host "Platforms: $Platforms"
 
 # Build Docker image
-docker build -f "$ROOT\Dockerfile" --build-arg APP_JAR=src/mcpagent/target/$jarName --build-arg BASE_IMAGE=admingentoro/gentoro:base-$Version -t "admingentoro/gentoro:$Version" -t "admingentoro/gentoro:latest" "$ROOT"
+try {
+    $buildArgs = @(
+        "buildx", "build",
+        "-f", "$ROOT\Dockerfile",
+        "--platform", "$Platforms",
+        "--build-arg", "APP_JAR=src/mcpagent/target/$JarName",
+        "--build-arg", "BASE_IMAGE=admingentoro/gentoro:base-$Version",
+        "-t", "admingentoro/gentoro:$Version",
+        "-t", "admingentoro/gentoro:latest"
+    )
+
+    if ($Push) {
+        Write-Host "Will push images to registry"
+        $buildArgs += "--push"
+    } else {
+        Write-Host "Building for local use (load to docker)"
+        # For local builds, we can only load one platform
+        $Platforms = "linux/amd64"
+        $buildArgs = @(
+            "buildx", "build",
+            "-f", "$ROOT\Dockerfile",
+            "--platform", "$Platforms",
+            "--build-arg", "APP_JAR=src/mcpagent/target/$JarName",
+            "--build-arg", "BASE_IMAGE=admingentoro/gentoro:base-$Version",
+            "-t", "admingentoro/gentoro:$Version",
+            "-t", "admingentoro/gentoro:latest",
+            "--load"
+        )
+    }
+
+    $buildArgs += "$ROOT"
+    
+    docker @buildArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "Docker build failed"
+    }
+    Write-Host "Successfully built admingentoro/gentoro:$Version for platforms: $Platforms"
+} catch {
+    Write-Error "Failed to build product image: $_"
+    exit 1
+}

--- a/scripts/docker/build-product.sh
+++ b/scripts/docker/build-product.sh
@@ -1,23 +1,72 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 VERSION="${1:-dev}"
+JAR_NAME="${2:-}"
+PUSH_FLAG="${3:-}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 POM="$ROOT_DIR/src/mcpagent/pom.xml"
 
-# Get version from POM
-POM_VERSION=$(xmllint --xpath "/*[local-name()='project']/*[local-name()='version']/text()" "$POM" 2>/dev/null || true)
-if [[ -z "$POM_VERSION" ]]; then
-  echo "Cannot read version from $POM"; exit 1
-fi
-JAR_NAME="mcpagent-$POM_VERSION.jar"
+# Default platforms for multi-arch builds
+PLATFORMS="${DOCKER_PLATFORMS:-linux/amd64,linux/arm64}"
 
-# Build app JAR
-( cd "$ROOT_DIR/src/mcpagent" && ./mvnw -q -DskipTests package || mvn -q -DskipTests package )
+# Get version from POM if JAR_NAME not provided
+if [[ -z "$JAR_NAME" ]]; then
+  POM_VERSION=$(xmllint --xpath "/*[local-name()='project']/*[local-name()='version']/text()" "$POM" 2>/dev/null || true)
+  if [[ -z "$POM_VERSION" ]]; then
+    echo "Cannot read version from $POM"; exit 1
+  fi
+  JAR_NAME="mcpagent-$POM_VERSION.jar"
+  
+  # Build app JAR if not already built
+  echo "Building application JAR..."
+  ( cd "$ROOT_DIR/src/mcpagent" && ./mvnw -q -DskipTests package || mvn -q -DskipTests package )
+fi
+
+# Validate JAR exists
+JAR_PATH="$ROOT_DIR/src/mcpagent/target/$JAR_NAME"
+if [[ ! -f "$JAR_PATH" ]]; then
+  echo "JAR file not found: $JAR_PATH"
+  exit 1
+fi
+
+echo "Building product image with version: $VERSION"
+echo "JAR: $JAR_NAME"
+echo "Platforms: $PLATFORMS"
+
+# Determine build command based on whether we're pushing
+BUILD_CMD="docker buildx build"
+BUILD_ARGS=(
+  -f "$ROOT_DIR/Dockerfile"
+  --platform "$PLATFORMS"
+  --build-arg "APP_JAR=src/mcpagent/target/$JAR_NAME"
+  --build-arg "BASE_IMAGE=admingentoro/gentoro:base-$VERSION"
+  -t "admingentoro/gentoro:$VERSION"
+  -t "admingentoro/gentoro:latest"
+)
+
+if [[ "$PUSH_FLAG" == "--push" ]]; then
+  echo "Will push images to registry"
+  BUILD_ARGS+=(--push)
+else
+  echo "Building for local use (load to docker)"
+  # For local builds, we can only load one platform
+  PLATFORMS="linux/amd64"
+  BUILD_ARGS=(
+    -f "$ROOT_DIR/Dockerfile"
+    --platform "$PLATFORMS"
+    --build-arg "APP_JAR=src/mcpagent/target/$JAR_NAME"
+    --build-arg "BASE_IMAGE=admingentoro/gentoro:base-$VERSION"
+    -t "admingentoro/gentoro:$VERSION"
+    -t "admingentoro/gentoro:latest"
+    --load
+  )
+fi
 
 # Build Docker image
-docker build -f "$ROOT_DIR/Dockerfile" \
-  --build-arg APP_JAR=src/mcpagent/target/$JAR_NAME \
-  --build-arg BASE_IMAGE=admingentoro/gentoro:base-$VERSION \
-  -t admingentoro/gentoro:$VERSION -t admingentoro/gentoro:latest "$ROOT_DIR"
+if ! $BUILD_CMD "${BUILD_ARGS[@]}" "$ROOT_DIR"; then
+  echo "Failed to build product image"
+  exit 1
+fi
 
-echo "Built admingentoro/gentoro:$VERSION"
+echo "Successfully built admingentoro/gentoro:$VERSION for platforms: $PLATFORMS"


### PR DESCRIPTION
## Changes

- Updated build scripts (`build-base.sh`, `build-product.sh`, PowerShell versions)
- Enhanced GitHub Actions workflow with QEMU and Docker Buildx
- Fix workflow issue https://github.com/Gentoro-HQ/mcpagent/issues/11

## Testing
- Base image builds successfully for both platforms
- AMD64 verified: x86_64, Java 21, Node 20
- ARM64 verified: aarch64, Java 21, Node 20 (via QEMU)

https://github.com/Gentoro-HQ/mcpagent/issues/13 