### PR TITLE
feat(Knowledge base): add robust logging, Javadoc, and file persistence; improve config init; standardize OpenAPI dir

### DIFF
--- a/src/acme-analytics-server/mcpagent-handbook/openapi/sales-analytics-api.yaml
+++ b/src/acme-analytics-server/mcpagent-handbook/openapi/sales-analytics-api.yaml
@@ -247,7 +247,6 @@ components:
       required:
         - field
         - operator
-        - value
       properties:
         field:
           type: string
@@ -263,7 +262,6 @@ components:
             - "sale.shipping_cost"
             - "sale.payment_method"
             - "sale.status"
-            
             # Product fields
             - "product.id"
             - "product.name"
@@ -276,7 +274,6 @@ components:
             - "product.rating"
             - "product.weight"
             - "product.dimensions"
-            
             # Customer fields
             - "customer.id"
             - "customer.name"
@@ -292,13 +289,11 @@ components:
             - "customer.loyalty_tier"
             - "customer.total_spent"
             - "customer.total_orders"
-            
             # Regional fields
             - "region.name"
             - "region.country"
             - "region.timezone"
             - "region.population"
-            
             # Time fields
             - "date.year"
             - "date.month"
@@ -325,12 +320,21 @@ components:
             - "is_null"
             - "is_not_null"
         value:
+          description: |
+            Value(s) to compare against. Optional for `is_null` and `is_not_null`.
+            For `between`, provide an array with exactly two values.
+          nullable: true
           oneOf:
             - type: string
             - type: number
             - type: boolean
             - type: array
-          description: Value(s) to compare against. For 'between' operator, use array with two values.
+              minItems: 1
+              items:
+                oneOf:
+                  - type: string
+                  - type: number
+                  - type: boolean
 
     AggregateFunction:
       type: object
@@ -370,6 +374,7 @@ components:
           items:
             type: object
             description: Flexible object structure based on requested fields
+            additionalProperties: true
         metadata:
           type: object
           properties:

--- a/src/mcpagent/README.md
+++ b/src/mcpagent/README.md
@@ -2,6 +2,24 @@
 
 This module contains the MCP Agent service and its tests.
 
+## Knowledge Base
+The agent builds a lightweight Knowledge Base from a Foundation directory on startup. It scans:
+- docs/*.md (and .mdx)
+- tests/** (all files)
+- feedback/* (all files)
+- openapi/*.(yaml|yml|json)
+
+Each discovered item becomes an entry addressable via an abstract URI: kb://<type>/<path>. The service maps these to original file:// paths or in-memory mem:// resources produced by OpenAPI SDK doc generation.
+
+Hints: For each entry a short hint is generated. If knowledgeBase.hint.useAi is true, the agent will call the configured LLM to produce a concise sentence; otherwise, it truncates the content to the configured length.
+
+Configuration (application.yaml):
+- knowledgeBase.foundation.dir (env: FOUNDATION_DIR) — Foundation root directory. Must exist.
+- knowledgeBase.hint.useAi — Use LLM to generate hints (default: false).
+- knowledgeBase.hint.size — Max hint length in characters.
+
+Caching: The computed entries and a signature are persisted to foundation/state/knowledge-base-state.json so subsequent startups can restore quickly when the Foundation directory has not changed.
+
 ## Running tests
 
 The project separates unit tests from integration tests using Maven Surefire and Failsafe.

--- a/src/mcpagent/src/main/java/com/gentorox/services/knowledgebase/FileKnowledgeBasePersistence.java
+++ b/src/mcpagent/src/main/java/com/gentorox/services/knowledgebase/FileKnowledgeBasePersistence.java
@@ -1,0 +1,87 @@
+package com.gentorox.services.knowledgebase;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * File-based implementation of {@link KnowledgeBasePersistence} that stores the knowledge base state as JSON.
+ * <p>
+ * Behavior:
+ * - load(Path): returns Optional.empty() when the path is not a regular file or does not exist.
+ * - save(Path, KnowledgeBaseState): ensures the parent directory exists, creates a timestamped backup if the
+ *   target file already exists, then writes the new state in pretty-printed JSON format.
+ */
+@Component
+public class FileKnowledgeBasePersistence implements KnowledgeBasePersistence {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileKnowledgeBasePersistence.class);
+
+  private final ObjectMapper objectMapper;
+
+  /**
+   * Constructs a new persistence component using a default Jackson {@link ObjectMapper} configured for pretty output.
+   */
+  public FileKnowledgeBasePersistence() {
+    this.objectMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+  }
+
+  /**
+   * Loads a {@link KnowledgeBaseState} from a JSON file if it exists and is a regular file.
+   *
+   * @param file the path to the JSON file; must not be null
+   * @return an Optional containing the loaded state, or empty if the file does not exist or is not a regular file
+   * @throws IOException if an I/O error occurs while reading or parsing the file
+   */
+  @Override
+  public Optional<KnowledgeBaseState> load(Path file) throws IOException {
+    Objects.requireNonNull(file, "file");
+
+    if (Files.isRegularFile(file)) {
+      LOGGER.debug("Loading KnowledgeBaseState from {}", file);
+      try (var in = Files.newBufferedReader(file)) {
+        return Optional.ofNullable(objectMapper.readValue(in, KnowledgeBaseState.class));
+      }
+    }
+
+    LOGGER.debug("KnowledgeBaseState file not found or not a regular file: {}", file);
+    return Optional.empty();
+  }
+
+  /**
+   * Saves the provided {@link KnowledgeBaseState} to the specified file as pretty-printed JSON.
+   * Creates the parent directory if necessary and writes a timestamped backup of the existing file, if present.
+   *
+   * @param file  the path to write the JSON file to; must not be null
+   * @param state the state to persist; must not be null
+   * @throws IOException if an I/O error occurs during writing or backup creation
+   */
+  @Override
+  public void save(Path file, KnowledgeBaseState state) throws IOException {
+    Objects.requireNonNull(file, "file");
+    Objects.requireNonNull(state, "state");
+
+    Path parent = file.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+
+    if (Files.exists(file)) {
+      Path backup = file.resolveSibling(file.getFileName() + ".bak." + System.currentTimeMillis());
+      LOGGER.info("Existing KnowledgeBaseState detected. Creating backup: {} -> {}", file, backup);
+      Files.move(file, backup);
+    }
+
+    LOGGER.debug("Saving KnowledgeBaseState to {}", file);
+    try (var out = Files.newBufferedWriter(file)) {
+      objectMapper.writeValue(out, state);
+    }
+  }
+}

--- a/src/mcpagent/src/main/java/com/gentorox/services/knowledgebase/KnowledgeBaseConfig.java
+++ b/src/mcpagent/src/main/java/com/gentorox/services/knowledgebase/KnowledgeBaseConfig.java
@@ -1,0 +1,58 @@
+package com.gentorox.services.knowledgebase;
+
+import com.gentorox.services.inference.InferenceService;
+import com.gentorox.services.typescript.TypescriptRuntimeClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Spring configuration for the Knowledge Base service.
+ *
+ * Properties:
+ * - knowledgeBase.foundation.dir: The root directory containing docs, tests, feedback, and openapi subfolders.
+ * - knowledgeBase.hint.useAi: Whether to use the InferenceService to generate short human-friendly hints for entries.
+ * - knowledgeBase.hint.size: Maximum length of the generated hint.
+ */
+@Configuration
+public class KnowledgeBaseConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(KnowledgeBaseConfig.class);
+
+  /**
+   * Builds and initializes the KnowledgeBaseService at startup.
+   */
+  @Bean
+  public KnowledgeBaseService knowledgeBaseService(
+                               @Value("${knowledgeBase.foundation.dir:/var/foundation}") String rootFoundationDir,
+                               @Value("${knowledgeBase.hint.useAi:false}") boolean hintAiGenerationEnabled,
+                               @Value("${knowledgeBase.hint.size:240}") int hintContentLimit,
+                               InferenceService inferenceService,
+                              TypescriptRuntimeClient tsRuntimeClient,
+                              KnowledgeBasePersistence persistence) throws IOException {
+    Path rootFoundationPath = Path.of(rootFoundationDir);
+    LOGGER.info("Initializing KnowledgeBaseService with foundation dir: {}", rootFoundationPath.toAbsolutePath());
+    if (!Files.exists(rootFoundationPath) || !Files.isDirectory(rootFoundationPath)) {
+      throw new IllegalStateException("Foundation dir not found: " + rootFoundationPath.toAbsolutePath());
+    }
+
+    Path stateDir = rootFoundationPath.resolve("state");
+    if (!Files.exists(stateDir)) {
+      Files.createDirectories(stateDir);
+      LOGGER.debug("Created state directory at {}", stateDir.toAbsolutePath());
+    }
+
+    Path stateFile = stateDir.resolve("knowledge-base-state.json");
+    LOGGER.info("KnowledgeBase hints: aiGenerationEnabled={}, maxLength={}", hintAiGenerationEnabled, hintContentLimit);
+    KnowledgeBaseService knowledgeBaseService = new KnowledgeBaseServiceImpl(inferenceService, tsRuntimeClient, persistence, stateFile, hintAiGenerationEnabled, hintContentLimit);
+    knowledgeBaseService.initialize(Path.of(rootFoundationDir));
+    LOGGER.info("KnowledgeBaseService initialized; state file: {}", stateFile.toAbsolutePath());
+    return knowledgeBaseService;
+  }
+
+}

--- a/src/mcpagent/src/main/java/com/gentorox/services/knowledgebase/KnowledgeBaseEntry.java
+++ b/src/mcpagent/src/main/java/com/gentorox/services/knowledgebase/KnowledgeBaseEntry.java
@@ -1,0 +1,28 @@
+package com.gentorox.services.knowledgebase;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Simple record representing a knowledge base entry that an LLM can load on-demand.
+ * Each entry has an abstract resource URI (e.g., kb://docs/Agent.md) and a short hint
+ * describing what the content contains. Content is the full textual payload.
+ *
+ * @param resource abstract resource URI, typically starting with kb://
+ * @param hint short human-friendly description of the content
+ * @param content full textual payload for the resource
+ */
+public record KnowledgeBaseEntry(
+    String resource,
+    String hint,
+    String content
+) {
+  @JsonCreator
+  public KnowledgeBaseEntry(@JsonProperty("resource") String resource,
+                            @JsonProperty("hint") String hint,
+                            @JsonProperty("content") String content) {
+    this.resource = resource;
+    this.hint = hint;
+    this.content = content;
+  }
+}

--- a/src/mcpagent/src/main/java/com/gentorox/services/knowledgebase/KnowledgeBasePersistence.java
+++ b/src/mcpagent/src/main/java/com/gentorox/services/knowledgebase/KnowledgeBasePersistence.java
@@ -1,0 +1,28 @@
+package com.gentorox.services.knowledgebase;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Persistence abstraction for storing and loading the compact knowledge base state.
+ */
+public interface KnowledgeBasePersistence {
+  /**
+   * Loads a previously persisted {@link KnowledgeBaseState} from the given file.
+   *
+   * @param file path to the JSON state file
+   * @return optional state if present and readable
+   * @throws IOException if an I/O error occurs during reading or parsing
+   */
+  Optional<KnowledgeBaseState> load(Path file) throws IOException;
+
+  /**
+   * Persists the provided {@link KnowledgeBaseState} to the given file.
+   *
+   * @param file destination file path
+   * @param state state to persist
+   * @throws IOException if an I/O error occurs while writing
+   */
+  void save(Path file, KnowledgeBaseState state) throws IOException;
+}

--- a/src/mcpagent/src/main/java/com/gentorox/services/knowledgebase/KnowledgeBaseService.java
+++ b/src/mcpagent/src/main/java/com/gentorox/services/knowledgebase/KnowledgeBaseService.java
@@ -1,0 +1,44 @@
+package com.gentorox.services.knowledgebase;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * High-level API for interacting with the knowledge base. Implementations expose abstract URIs with the
+ * "kb://" scheme which are resolved to original sources on demand.
+ */
+public interface KnowledgeBaseService {
+  /**
+   * Initialize the knowledge base by attempting to restore from a persisted state, or by scanning the
+   * provided foundation directory when the state is missing or stale.
+   *
+   * @param foundationRoot root folder containing docs, tests, feedback, and openapi subfolders; may be null
+   */
+  void initialize(Path foundationRoot);
+
+  /**
+   * List all entries under a given directory-like prefix. If dir is null or blank, list all.
+   * The service exposes abstract knowledge base URIs with the scheme "kb://".
+   * Examples: "kb://docs" or "kb://docs/Agent.md".
+   *
+   * @param dirPrefix abstract kb prefix
+   * @return entries sorted by resource URI
+   */
+  List<KnowledgeBaseEntry> list(String dirPrefix);
+
+  /**
+   * Retrieve the full textual content of a resource URI (supports kb://, file://, and in-memory mem:// indirection).
+   *
+   * @param resourceUri kb:// or original URI
+   * @return optional content
+   */
+  Optional<String> getContent(String resourceUri);
+
+  /**
+   * Whether the KB was restored from persisted state during the last initialization.
+   *
+   * @return true if loaded from cache
+   */
+  boolean loadedFromCache();
+}

--- a/src/mcpagent/src/main/java/com/gentorox/services/knowledgebase/KnowledgeBaseServiceImpl.java
+++ b/src/mcpagent/src/main/java/com/gentorox/services/knowledgebase/KnowledgeBaseServiceImpl.java
@@ -1,0 +1,415 @@
+package com.gentorox.services.knowledgebase;
+
+import com.gentorox.core.model.InferenceResponse;
+import com.gentorox.services.inference.InferenceService;
+import com.gentorox.services.typescript.TypescriptRuntimeClient;
+import com.gentorox.services.typescript.TypescriptRuntimeClient.DocsResponse;
+import com.gentorox.services.typescript.TypescriptRuntimeClient.DocFile;
+import com.gentorox.services.typescript.TypescriptRuntimeClient.UploadResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Default KnowledgeBaseService implementation.
+ *
+ * Features:
+ * - Scans a Foundation directory for docs (docs/*.md), tests (tests/**), feedback, and OpenAPI specs.
+ * - Produces abstract kb:// URIs mapped to original file:// or in-memory mem:// resources.
+ * - Optionally generates concise hints using the configured InferenceService (or falls back to first bytes).
+ * - Persists a lightweight KnowledgeBaseState so startup can restore from cache when nothing changed.
+ */
+/**
+ * Default implementation of {@link KnowledgeBaseService} that builds a lightweight searchable catalog of
+ * foundation documents, tests, feedback, and generated OpenAPI docs. It persists a compact state to speed up
+ * subsequent startups by restoring from cache when no changes are detected.
+ */
+public class KnowledgeBaseServiceImpl implements KnowledgeBaseService {
+  private static final Logger LOGGER = LoggerFactory.getLogger(KnowledgeBaseServiceImpl.class);
+  private final InferenceService inferenceService;
+  private final TypescriptRuntimeClient tsRuntimeClient;
+  private final KnowledgeBasePersistence persistence;
+
+  // Entries are keyed by abstracted kb:// URIs
+  private final Map<String, KnowledgeBaseEntry> entries = new ConcurrentHashMap<>();
+  // Map abstract kb:// -> original (file:// or mem://) for content resolution
+  private final Map<String, String> abstractToOriginal = new ConcurrentHashMap<>();
+  // In-memory content for mem:// resources
+  private final Map<String, String> inMemoryContent = new ConcurrentHashMap<>();
+  private boolean loadedFromCache = false;
+  private Path stateFile;
+  private Path foundationRoot;
+  private final boolean aiHintGenerationEnabled;
+  private final int hintContentLimit;
+
+  /**
+   * Creates a new service instance.
+   *
+   * @param inferenceService service used to optionally generate human-friendly hints
+   * @param tsRuntimeClient Typescript runtime client used for OpenAPI SDK generation and docs fetching
+   * @param persistence persistence component used to store/load a compact KB state
+   * @param stateFile file where the KB state is persisted; if null, a default under target/kb is used
+   * @param aiHintGenerationEnabled whether AI-based hint generation is enabled
+   * @param hintContentLimit maximum hint length in characters
+   */
+  public KnowledgeBaseServiceImpl(InferenceService inferenceService,
+                                  TypescriptRuntimeClient tsRuntimeClient,
+                                  KnowledgeBasePersistence persistence,
+                                  Path stateFile,
+                                  boolean aiHintGenerationEnabled,
+                                  int hintContentLimit) {
+    this.inferenceService = Objects.requireNonNull(inferenceService, "inferenceService");
+    this.tsRuntimeClient = Objects.requireNonNull(tsRuntimeClient, "tsRuntimeClient");
+    this.persistence = Objects.requireNonNull(persistence, "persistence");
+    this.stateFile = (stateFile != null) ? stateFile : Path.of("target/kb/knowledge-base-state.json");
+    this.aiHintGenerationEnabled = aiHintGenerationEnabled;
+    this.hintContentLimit = hintContentLimit;
+  }
+
+  public KnowledgeBaseServiceImpl(InferenceService inferenceService,
+                                  TypescriptRuntimeClient tsRuntimeClient,
+                                  KnowledgeBasePersistence persistence) {
+    this(inferenceService, tsRuntimeClient, persistence,
+        Path.of("target/kb/knowledge-base-state.json"), false, 240);
+  }
+
+  /**
+   * Initializes the knowledge base by attempting to restore from the persisted state file. If the state
+   * is missing or stale (signature mismatch), performs a fresh scan of the foundation directory and then
+   * persists the new state.
+   *
+   * @param foundationRoot the root directory containing docs, tests, feedback, and openapi; if null, defaults to "foundation"
+   */
+  @Override
+  public void initialize(Path foundationRoot) {
+    if (foundationRoot == null) foundationRoot = Path.of("foundation");
+    this.foundationRoot = foundationRoot.toAbsolutePath().normalize();
+
+    String signature = computeSignature(foundationRoot);
+    try {
+      Optional<KnowledgeBaseState> cached = persistence.load(stateFile);
+      if (cached.isPresent() && Objects.equals(cached.get().signature(), signature)) {
+        entries.clear();
+        abstractToOriginal.clear();
+        inMemoryContent.clear();
+        for (KnowledgeBaseEntry e : cached.get().entries()) {
+          // Entries are stored with abstract URIs
+          entries.put(e.resource(), e);
+        }
+        loadedFromCache = true;
+        return;
+      }
+    } catch (IOException e) { LOGGER.warn("Failed to load KnowledgeBaseState from {}", stateFile, e); }
+
+    // Fresh build
+    entries.clear();
+    abstractToOriginal.clear();
+    inMemoryContent.clear();
+    loadedFromCache = false;
+
+    ingestFoundation(foundationRoot);
+
+    // Persist state
+    try {
+      var state = new KnowledgeBaseState(signature, new ArrayList<>(entries.values()));
+      persistence.save(stateFile, state);
+    } catch (IOException e) { LOGGER.warn("Failed to persist KnowledgeBaseState to {}", stateFile, e); }
+  }
+
+  /**
+   * Lists knowledge base entries under the provided abstract directory prefix.
+   * If the prefix is null or blank, all entries are returned.
+   *
+   * @param dirPrefix a prefix like "kb://docs" or "kb://openapi"; may be null/blank
+   * @return sorted list of entries by resource URI
+   */
+  @Override
+  public List<KnowledgeBaseEntry> list(String dirPrefix) {
+    if (dirPrefix == null || dirPrefix.isBlank()) return entries.values().stream()
+        .sorted(Comparator.comparing(KnowledgeBaseEntry::resource))
+        .toList();
+    String prefix = dirPrefix;
+    return entries.values().stream()
+        .filter(e -> e.resource().startsWith(prefix))
+        .sorted(Comparator.comparing(KnowledgeBaseEntry::resource))
+        .toList();
+  }
+
+  /**
+   * Resolves and returns the full textual content for a given resource URI.
+   * Supports indirection from abstract kb:// URIs to original file:// or in-memory mem:// locations.
+   *
+   * @param resourceUri the abstract or original URI
+   * @return the content if available
+   */
+  @Override
+  public Optional<String> getContent(String resourceUri) {
+    try {
+      // If the given URI is abstract, resolve to original
+      String original = abstractToOriginal.getOrDefault(resourceUri, null);
+
+      if (original == null && resourceUri != null && resourceUri.startsWith("kb://")) {
+        original = resolveOriginalFromAbstract(resourceUri).orElse(null);
+      }
+
+      if (original == null) return Optional.empty();
+
+      // Check in-memory bucket for mem:// originals
+      if (original.startsWith("mem://")) {
+        return Optional.ofNullable(inMemoryContent.get(original));
+      }
+
+      // Otherwise treat as file:// URI
+      URI uri = new URI(original);
+      if (!"file".equalsIgnoreCase(uri.getScheme())) return Optional.empty();
+      Path p = Path.of(uri);
+      if (Files.isRegularFile(p)) {
+        try {
+          return Optional.of(Files.readString(p));
+        } catch (IOException e) {
+          LOGGER.debug("Failed to read content from file {}", p, e);
+          return Optional.empty();
+        }
+      }
+    } catch (URISyntaxException e) { LOGGER.debug("Invalid resource URI: {}", resourceUri, e); }
+    return Optional.empty();
+  }
+
+  /**
+   * Indicates whether the entries were restored from a persisted cache during initialization.
+   *
+   * @return true if restored from cache; false if freshly built
+   */
+  @Override
+  public boolean loadedFromCache() { return loadedFromCache; }
+
+  private Optional<String> resolveOriginalFromAbstract(String abstractUri) {
+    if (abstractUri == null || !abstractUri.startsWith("kb://")) return Optional.empty();
+    String rest = abstractUri.substring("kb://".length());
+    int idx = rest.indexOf('/');
+    if (idx <= 0) return Optional.empty();
+    String type = rest.substring(0, idx);
+    String path = rest.substring(idx + 1);
+
+    try {
+      switch (type) {
+        case "docs" -> {
+          if (foundationRoot == null) return Optional.empty();
+          Path p = foundationRoot.resolve("docs").resolve(path);
+          return Optional.of(toFileUri(p));
+        }
+        case "tests" -> {
+          if (foundationRoot == null) return Optional.empty();
+          Path p = foundationRoot.resolve("tests").resolve(path);
+          return Optional.of(toFileUri(p));
+        }
+        case "feedback" -> {
+          if (foundationRoot == null) return Optional.empty();
+          Path p = foundationRoot.resolve("feedback").resolve(path);
+          return Optional.of(toFileUri(p));
+        }
+        case "openapi" -> {
+          // path: {namespace}/docs/<file>
+          int i = path.indexOf('/');
+          if (i <= 0) return Optional.empty();
+          String namespace = path.substring(0, i);
+          String afterNs = path.substring(i + 1);
+          String restPath = afterNs.startsWith("docs/") ? afterNs.substring("docs/".length()) : afterNs;
+          Path p = Path.of(System.getProperty("java.io.tmpdir"), "external-sdks", namespace, "docs.openapi-generator.markdown").resolve(restPath);
+          return Optional.of(toFileUri(p));
+        }
+        default -> { return Optional.empty(); }
+      }
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
+  private void ingestFoundation(Path root) {
+    // Agent.md -> treat as docs/Agent.md
+    Path agent = root.resolve("Agent.md");
+    if (Files.isRegularFile(agent)) {
+      addFoundationFile(agent, "docs", agent.getFileName().toString());
+    }
+
+    // docs/*.md
+    Path docsDir = root.resolve("docs");
+    if (Files.isDirectory(docsDir)) {
+      try (var stream = Files.list(docsDir)) {
+        stream.filter(p -> Files.isRegularFile(p) && hasExtension(p, ".md", ".mdx"))
+            .forEach(p -> addFoundationFile(p, "docs", p.getFileName().toString()));
+      } catch (IOException e) { LOGGER.debug("Failed to list docs directory {}", docsDir, e); }
+    }
+
+    // feedback/* (treat as markdown or text)
+    Path feedbackDir = root.resolve("feedback");
+    if (Files.isDirectory(feedbackDir)) {
+      try (var stream = Files.list(feedbackDir)) {
+        stream.filter(Files::isRegularFile)
+            .forEach(p -> addFoundationFile(p, "feedback", p.getFileName().toString()));
+      } catch (IOException e) { LOGGER.debug("Failed to list feedback directory {}", feedbackDir, e); }
+    }
+
+    // tests/* (optional include - they are useful context sometimes)
+    Path testsDir = root.resolve("tests");
+    if (Files.isDirectory(testsDir)) {
+      try (var stream = Files.walk(testsDir)) {
+        stream.filter(Files::isRegularFile)
+            .forEach(p -> {
+              Path rel = testsDir.relativize(p);
+              addFoundationFile(p, "tests", rel.toString().replace('\\','/'));
+            });
+      } catch (IOException e) { LOGGER.debug("Failed to walk tests directory {}", testsDir, e); }
+    }
+
+    // specs -> OpenAPI transformation (yaml/json)
+    Path specsDir = root.resolve("openapi");
+    if (Files.isDirectory(specsDir)) {
+      try (var stream = Files.list(specsDir)) {
+        stream.filter(p -> Files.isRegularFile(p) && hasExtension(p, ".yaml", ".yml", ".json"))
+            .forEach(this::processOpenApiSpec);
+      } catch (IOException e) { LOGGER.debug("Failed to list specs directory {}", specsDir, e); }
+    }
+  }
+
+  private void addFoundationFile(Path file, String type, String relativePath) {
+    String original = toFileUri(file);
+    String abstractUri = "kb://" + type + "/" + relativePath;
+    String content = readSafe(file);
+    String hint = generateHint(file.getFileName().toString(), content);
+    entries.put(abstractUri, new KnowledgeBaseEntry(abstractUri, hint, content));
+    abstractToOriginal.put(abstractUri, original);
+  }
+
+  private void processOpenApiSpec(Path spec) {
+    String outDir = "openapi_" + safeSdkName(spec.getFileName().toString());
+    try {
+      UploadResult up = tsRuntimeClient.uploadOpenapi(spec, outDir)
+          .onErrorResume(e -> {
+            LOGGER.error("Failed to upload OpenAPI spec to Typescript runtime", e);
+            return Mono.empty();
+          }).blockOptional().orElse(null);
+      if (up == null || up.sdk() == null || up.sdk().namespace() == null) {
+        throw new RuntimeException("Failed to upload OpenAPI spec to Typescript runtime");
+      }
+      DocsResponse docs = tsRuntimeClient.fetchDocs(up.sdk().namespace(), false).onErrorResume(e -> Mono.empty()).blockOptional().orElse(null);
+      if (docs != null && docs.files() != null && !docs.files().isEmpty()) {
+        String baseDisk = docs.diskLocation();
+        for (DocFile f : docs.files()) {
+          String content = Optional.ofNullable(f.markdown()).orElse("");
+          String namespace = docs.namespace();
+          String original;
+          if (baseDisk != null && !baseDisk.isBlank()) {
+            original = toFileUri(Path.of(baseDisk).resolve(f.path()));
+          } else {
+            // Virtual in-memory resource
+            original = "mem://openapi/" + namespace + "/" + f.path();
+            inMemoryContent.put(original, content);
+          }
+          String abstractUri = "kb://openapi/" + namespace + "/docs/" + f.path();
+          String hint = generateHint(f.path(), content);
+          entries.put(abstractUri, new KnowledgeBaseEntry(abstractUri, hint, content));
+          abstractToOriginal.put(abstractUri, original);
+        }
+      }
+    } catch (Exception e) {
+      // On any error, at least index the raw spec file under openapi type
+      LOGGER.warn("Failed to process OpenAPI spec {}, indexing raw file instead", spec, e);
+      addFoundationFile(spec, "openapi", spec.getFileName().toString());
+    }
+  }
+
+  private String generateHint(String name, String content) {
+    // Prefer a short LLM-produced hint, fallback to heuristic first lines
+    try {
+      String txt;
+      if(aiHintGenerationEnabled) {
+        String prompt = "Given the following file name and content, produce a single concise sentence (max 30 words) that describes what information this document contains, focusing on how an engineer would use it.\n" +
+            "File: " + name + "\n\n" +
+            "Content (first 800 chars):\n" + truncate(content, 800);
+        InferenceResponse resp = inferenceService.sendRequest(prompt, List.of());
+        txt = Optional.ofNullable(resp).map(InferenceResponse::content).orElse("");
+      } else {
+        txt = content.substring(0, Math.min(content.length(), hintContentLimit)) + "...";
+      }
+      txt = sanitizeHint(txt, hintContentLimit);
+      if (!txt.isBlank()) return txt;
+    } catch (Exception ignored) { }
+    // Fallback
+    String first = Arrays.stream(content.split("\n"))
+        .map(String::trim)
+        .filter(s -> !s.isBlank())
+        .findFirst().orElse(name);
+    return (first.length() > hintContentLimit) ? first.substring(0, hintContentLimit) + "…" : first;
+  }
+
+  private static String sanitizeHint(String s, int hintSize) {
+    if (s == null) return "";
+    s = s.replaceAll("^[\"'`]+|[\"'`]+$", ""); // trim quotes
+    s = s.replaceAll("\n+", " ").trim();
+    if (s.length() > hintSize) s = s.substring(0, hintSize) + "…";
+    return s;
+  }
+
+  private static String truncate(String s, int max) {
+    if (s == null) return "";
+    byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+    if (bytes.length <= max) return s;
+    return new String(Arrays.copyOf(bytes, max), StandardCharsets.UTF_8);
+  }
+
+  private static boolean hasExtension(Path p, String... exts) {
+    String n = p.getFileName().toString().toLowerCase(Locale.ROOT);
+    for (String e : exts) if (n.endsWith(e)) return true;
+    return false;
+  }
+
+  private static String toFileUri(Path p) { return p.toAbsolutePath().toUri().toString(); }
+  private static String readSafe(Path p) { try { return Files.readString(p); } catch (IOException e) { return ""; } }
+
+  private static String safeSdkName (String name) {
+    return stripExt(name).replaceAll("[^a-zA-Z0-9]", "_");
+  }
+
+  private static String stripExt(String name) {
+    int i = name.lastIndexOf('.') ;
+    return (i > 0) ? name.substring(0, i) : name;
+  }
+
+  private static String computeSignature(Path root) {
+    // Simple signature: concatenate file names + lastModified for known subtrees
+    List<Path> toScan = new ArrayList<>();
+    toScan.add(root);
+    toScan.add(root.resolve("docs"));
+    toScan.add(root.resolve("openapi"));
+    toScan.add(root.resolve("tests"));
+    toScan.add(root.resolve("feedback"));
+    StringBuilder sb = new StringBuilder();
+    for (Path dir : toScan) {
+      if (Files.isDirectory(dir)) {
+        try (var walk = Files.walk(dir)) {
+          walk.filter(Files::isRegularFile).sorted()
+              .forEach(f -> {
+                try {
+                  sb.append(f.toAbsolutePath()).append('|').append(Files.getLastModifiedTime(f).toMillis()).append('\n');
+                } catch (IOException e) { LOGGER.debug("Failed to read lastModifiedTime for {}", f, e); }
+              });
+        } catch (IOException e) { LOGGER.debug("Failed to walk directory {}", dir, e); }
+      } else if (Files.isRegularFile(dir)) {
+        try {
+          sb.append(dir.toAbsolutePath()).append('|').append(Files.getLastModifiedTime(dir).toMillis()).append('\n');
+        } catch (IOException e) { LOGGER.debug("Failed to read lastModifiedTime for {}", dir, e); }
+      }
+    }
+    return Integer.toHexString(sb.toString().hashCode());
+  }
+}

--- a/src/mcpagent/src/main/java/com/gentorox/services/knowledgebase/KnowledgeBaseState.java
+++ b/src/mcpagent/src/main/java/com/gentorox/services/knowledgebase/KnowledgeBaseState.java
@@ -1,0 +1,24 @@
+package com.gentorox.services.knowledgebase;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Serializable state of the Knowledge Base, so we can persist and restore quickly on startup.
+ *
+ * @param signature content signature used to detect changes
+ * @param entries entries included in the knowledge base
+ */
+public record KnowledgeBaseState(
+    String signature,
+    List<KnowledgeBaseEntry> entries
+) {
+  @JsonCreator
+  public KnowledgeBaseState(@JsonProperty("signature") String signature,
+                            @JsonProperty("entries") List<KnowledgeBaseEntry> entries) {
+    this.signature = signature;
+    this.entries = entries;
+  }
+}

--- a/src/mcpagent/src/main/resources/application.yaml
+++ b/src/mcpagent/src/main/resources/application.yaml
@@ -58,3 +58,17 @@ kb:
 otel:
   service:
     name: mcpagent
+
+
+knowledgeBase:
+  # Root Foundation directory containing docs/, tests/, feedback/, and openapi/ subfolders.
+  # Override with env var FOUNDATION_DIR or set knowledgeBase.foundation.dir
+  foundation:
+    dir: ${FOUNDATION_DIR:/var/foundation}
+  # Hint generation settings for KB entries
+  hint:
+    # Max characters used when generating hints (also caps AI output)
+    size: 500
+    # If true, uses the configured InferenceService to generate a concise hint for each entry.
+    # Otherwise, falls back to the first N characters of the content.
+    useAi: false

--- a/src/mcpagent/src/test/java/com/gentorox/services/knowledgebase/FileKnowledgeBasePersistenceTest.java
+++ b/src/mcpagent/src/test/java/com/gentorox/services/knowledgebase/FileKnowledgeBasePersistenceTest.java
@@ -1,0 +1,42 @@
+package com.gentorox.services.knowledgebase;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FileKnowledgeBasePersistenceTest {
+
+  @Test
+  void loadReturnsEmptyWhenFileDoesNotExist(@TempDir Path tmp) throws Exception {
+    FileKnowledgeBasePersistence p = new FileKnowledgeBasePersistence();
+    Path file = tmp.resolve("kb-state.json");
+    assertFalse(Files.exists(file));
+    Optional<KnowledgeBaseState> st = p.load(file);
+    assertTrue(st.isEmpty());
+  }
+
+  @Test
+  void saveAndLoadRoundTrip(@TempDir Path tmp) throws Exception {
+    FileKnowledgeBasePersistence p = new FileKnowledgeBasePersistence();
+    Path file = tmp.resolve("kb/knowledge-base-state.json");
+
+    KnowledgeBaseEntry e1 = new KnowledgeBaseEntry("file:///a.md", "doc a", "doc a");
+    KnowledgeBaseEntry e2 = new KnowledgeBaseEntry("mem://b.md", "doc b", "doc b");
+    KnowledgeBaseState state = new KnowledgeBaseState("sig-123", List.of(e1, e2));
+
+    p.save(file, state);
+    assertTrue(Files.exists(file));
+
+    Optional<KnowledgeBaseState> loaded = p.load(file);
+    assertTrue(loaded.isPresent());
+    assertEquals("sig-123", loaded.get().signature());
+    assertEquals(2, loaded.get().entries().size());
+    assertEquals("file:///a.md", loaded.get().entries().get(0).resource());
+  }
+}

--- a/src/mcpagent/src/test/java/com/gentorox/services/knowledgebase/KnowledgeBaseServiceImplTest.java
+++ b/src/mcpagent/src/test/java/com/gentorox/services/knowledgebase/KnowledgeBaseServiceImplTest.java
@@ -1,0 +1,153 @@
+package com.gentorox.services.knowledgebase;
+
+import com.gentorox.core.model.InferenceResponse;
+import com.gentorox.services.inference.InferenceService;
+import com.gentorox.services.typescript.TypescriptRuntimeClient;
+import com.gentorox.services.typescript.TypescriptRuntimeClient.DocsResponse;
+import com.gentorox.services.typescript.TypescriptRuntimeClient.DocFile;
+import com.gentorox.services.typescript.TypescriptRuntimeClient.Sdk;
+import com.gentorox.services.typescript.TypescriptRuntimeClient.UploadResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class KnowledgeBaseServiceImplTest {
+
+  InferenceService inference;
+  TypescriptRuntimeClient ts;
+  KnowledgeBasePersistence persistence;
+
+  @BeforeEach
+  void setUp() {
+    inference = Mockito.mock(InferenceService.class);
+    // Return a short deterministic hint regardless of prompt
+    when(inference.sendRequest(any(), any())).thenReturn(new InferenceResponse("test hint", Optional.empty(), "trace"));
+
+    ts = Mockito.mock(TypescriptRuntimeClient.class);
+
+    persistence = new FileKnowledgeBasePersistence();
+  }
+
+  private static void setStateFile(KnowledgeBaseServiceImpl svc, Path stateFile) throws Exception {
+    Field f = KnowledgeBaseServiceImpl.class.getDeclaredField("stateFile");
+    f.setAccessible(true);
+    f.set(svc, stateFile);
+  }
+
+  @Test
+  void ingestsFoundationAndListsAndGetsContent(@TempDir Path tmp) throws Exception {
+    // Create foundation structure
+    Path foundation = tmp.resolve("foundation");
+    Files.createDirectories(foundation);
+    Files.writeString(foundation.resolve("Agent.md"), "# Agent\nBehave well.");
+
+    Path docs = Files.createDirectories(foundation.resolve("docs"));
+    Path doc1 = docs.resolve("documentation_1.md");
+    Files.writeString(doc1, "Doc1 content");
+
+    Path feedback = Files.createDirectories(foundation.resolve("feedback"));
+    Path fb = feedback.resolve("notes.txt");
+    Files.writeString(fb, "Some feedback");
+
+    Path tests = Files.createDirectories(foundation.resolve("tests"));
+    Path t1 = tests.resolve("test1.txt");
+    Files.writeString(t1, "Test data");
+
+    KnowledgeBaseServiceImpl svc = new KnowledgeBaseServiceImpl(inference, ts, persistence);
+    setStateFile(svc, tmp.resolve("kb/state.json"));
+
+    svc.initialize(foundation);
+
+    // Verify entries
+    var entries = svc.list(null);
+    assertTrue(entries.size() >= 4, "Expected at least 4 entries");
+
+    // Check listing by prefix
+    String docsPrefix = "kb://docs";
+    var docsEntries = svc.list(docsPrefix);
+    assertFalse(docsEntries.isEmpty());
+    assertTrue(docsEntries.stream().allMatch(e -> e.resource().startsWith(docsPrefix)));
+
+    // getContent for a KB resource
+    String fileRes = "kb://docs/" + doc1.getFileName().toString();
+    Optional<String> content = svc.getContent(fileRes);
+    assertTrue(content.isPresent());
+    assertEquals("Doc1 content", content.get());
+
+    // No TS client interactions in this test
+    verifyNoInteractions(ts);
+  }
+
+  @Test
+  void usesCacheOnSecondInitialization(@TempDir Path tmp) throws Exception {
+    Path foundation = tmp.resolve("foundation");
+    Files.createDirectories(foundation);
+    Files.writeString(foundation.resolve("Agent.md"), "# Agent\nBehave well.");
+
+    KnowledgeBaseServiceImpl svc = new KnowledgeBaseServiceImpl(inference, ts, persistence);
+    Path statePath = tmp.resolve("kb/state.json");
+    setStateFile(svc, statePath);
+
+    // First run builds and saves
+    svc.initialize(foundation);
+    assertFalse(svc.loadedFromCache());
+    assertTrue(Files.exists(statePath));
+
+    // Clear invocations and re-init, should load from cache and avoid inference calls
+    clearInvocations(inference);
+
+    KnowledgeBaseServiceImpl svc2 = new KnowledgeBaseServiceImpl(inference, ts, persistence);
+    setStateFile(svc2, statePath);
+    svc2.initialize(foundation);
+
+    assertTrue(svc2.loadedFromCache());
+    verifyNoInteractions(ts);
+    verifyNoInteractions(inference);
+  }
+
+  @Test
+  void processesOpenApiSpecsAndCreatesMemDocs(@TempDir Path tmp) throws Exception {
+    Path foundation = tmp.resolve("foundation");
+    Files.createDirectories(foundation);
+    Path specs = Files.createDirectories(foundation.resolve("openapi"));
+    Path spec = specs.resolve("api.json");
+    Files.writeString(spec, "{\n  \"openapi\": \"3.0.0\",\n  \"info\": {\"title\": \"Sample API\"},\n  \"paths\": {}\n}");
+
+    // Mock upload + docs
+    when(ts.uploadOpenapi(eq(spec), any())).thenReturn(Mono.just(new UploadResult(true, new Sdk("ns1", "/tmp/sdk/ns1", "file:///tmp/sdk/ns1/index.ts"), "ok")));
+    List<DocFile> files = List.of(new DocFile("ServiceApi.md", "# Service API\nDetails."));
+    when(ts.fetchDocs(eq("ns1"), eq(false))).thenReturn(Mono.just(new DocsResponse(true, "ns1", files.size(), files, null, "generated")));
+
+    KnowledgeBaseServiceImpl svc = new KnowledgeBaseServiceImpl(inference, ts, persistence);
+    setStateFile(svc, tmp.resolve("kb/state.json"));
+
+    svc.initialize(foundation);
+
+    var entries = svc.list("kb://openapi/ns1");
+    assertEquals(1, entries.size());
+    KnowledgeBaseEntry e = entries.get(0);
+    assertTrue(e.resource().equals("kb://openapi/ns1/docs/ServiceApi.md"));
+
+    // Ensure getContent works for kb resource
+    var content = svc.getContent(e.resource());
+    assertTrue(content.isPresent());
+    assertTrue(content.get().contains("Service API"));
+
+    // Verify TS client interacted
+    verify(ts, times(1)).uploadOpenapi(eq(spec), any());
+    verify(ts, times(1)).fetchDocs(eq("ns1"), eq(false));
+  }
+}

--- a/src/typescript-runtime/README.md
+++ b/src/typescript-runtime/README.md
@@ -2,6 +2,7 @@
 
 This package provides a small Fastify service that can:
 - Accept an OpenAPI spec upload, generate a TypeScript SDK, and register it under a unique namespace.
+- Generate Markdown documentation for any generated SDK using OpenAPI Generator’s built-in `markdown` generator.
 - Execute TypeScript snippets in a sandboxed isolate where the SDKs are available under the `sdk` object.
 
 It’s designed for rapid prototyping and safe execution of small snippets that call external APIs via generated clients.
@@ -11,7 +12,8 @@ It’s designed for rapid prototyping and safe execution of small snippets that 
 ## Features
 
 - Dynamic snippet execution via `POST /run` with memory/time limits.
-- OpenAPI codegen via `POST /sdk/upload` using openapi-typescript-codegen.
+- Real-time SDK generation via `POST /sdk/upload` using **OpenAPI Generator (typescript-axios)**.
+- Real-time documentation generation via `GET /sdk/docs/:namespace` using **OpenAPI Generator (markdown)**.
 - Automatic discovery and namespacing of generated SDKs.
 - Sandboxed runtime with an axios-style HTTP bridge managed on the host side.
 - Fully ESM module setup ("type": "module"); Node.js >= 20 required.
@@ -47,36 +49,97 @@ PORT=3001 EXTERNAL_SDKS_ROOT=./.sdks pnpm dev
 ## Endpoints
 
 ### POST /sdk/upload
-Multipart form-data:
-- spec: required file field (.yaml or .json)
-- outDir: optional folder name; will be sanitized and made unique
 
-Example:
+Generates a TypeScript SDK from an uploaded OpenAPI specification.
+
+**Multipart form-data:**
+- `spec`: required file field (.yaml or .json)
+- `outDir`: optional folder name; sanitized and made unique
+
+**Example:**
 
 ```bash
-curl -s -X POST "http://localhost:3000/sdk/upload" \
-  -H "content-type: multipart/form-data" \
-  -F "spec=@./petstore.yaml" \
-  -F "outDir=petstore"
+curl -s -X POST "http://localhost:3000/sdk/upload"   -H "content-type: multipart/form-data"   -F "spec=@./petstore.yaml"   -F "outDir=petstore"
 ```
 
-Successful response contains the namespace, absolute location, and entry file path.
+**Successful response:**
 
-### POST /run
-JSON body:
-- snippet: required string with TypeScript/JavaScript code
+```json
+{
+  "ok": true,
+  "sdk": {
+    "namespace": "petstore",
+    "location": "/tmp/external-sdks/petstore",
+    "entry": "file:///tmp/external-sdks/petstore/index.ts"
+  },
+  "message": "SDK generated via OpenAPI Generator (typescript-axios)."
+}
+```
 
-Example:
+The generated SDK is available under `sdk.<namespace>` in snippets.
+
+---
+
+### GET /sdk/docs/:namespace
+
+Generates Markdown documentation for a previously generated SDK and returns it as a JSON collection.
+
+**Query parameters:**
+- `cleanup` (optional, boolean): when `true`, forces regeneration by deleting existing docs.
+
+**Example:**
 
 ```bash
-curl -X POST http://localhost:3000/run \
-  -H "Content-Type: application/json" \
-  -d '{
-    "snippet": "sdk.petstore.OpenAPI.BASE = \"https://api.example.com/pets\"; const pets = await sdk.petstore.PetsService.listPets({ limit: 2 }); const result = pets.length;"
+curl -s "http://localhost:3000/sdk/docs/petstore?cleanup=true"
+```
+
+**Successful response:**
+
+```json
+{
+  "ok": true,
+  "namespace": "petstore",
+  "count": 42,
+  "files": [
+    { "path": "PetsApi.md", "markdown": "# PetsApi\n\n## listPets\n..." },
+    { "path": "UsersApi.md", "markdown": "# UsersApi\n..." }
+  ],
+  "diskLocation": "/tmp/external-sdks/petstore/docs.openapi-generator.markdown",
+  "message": "Documentation generated via OpenAPI Generator (markdown)."
+}
+```
+
+Each entry in `files[]` corresponds to a Markdown document that describes a service, model, or endpoint.  
+These are suitable for rendering in UI viewers, feeding to LLMs, or syncing to external documentation systems.
+
+---
+
+### POST /run
+
+Executes arbitrary TypeScript/JavaScript code in an isolated VM context.
+
+**JSON body:**
+- `snippet`: required string with TypeScript/JavaScript code
+
+**Example:**
+
+```bash
+curl -X POST http://localhost:3000/run   -H "Content-Type: application/json"   -d '{
+    "snippet": "sdk.petstore.OpenAPI.BASE = \"https://api.example.com/pets\"; const pets = await sdk.petstore.PetsApi.listPets({ limit: 2 }); console.log(pets);"
   }'
 ```
 
-The response returns { ok, value?, error?, logs } where logs capture console.log/error/warn.
+**Response:**
+
+```json
+{
+  "ok": true,
+  "value": null,
+  "logs": ["[PetsApi] listPets() -> 2 results"]
+}
+```
+
+The response returns `{ ok, value?, error?, logs }` where logs capture console output from the isolated execution.
 
 ---
 
@@ -91,44 +154,42 @@ Environment variables:
 | SNIPPET_MEM_MB       | 128                   | Memory limit per snippet (MB)       |
 | SNIPPET_TIMEOUT_MS   | 60000                 | Max execution time per snippet (ms) |
 
-Rationale: a /tmp default avoids accumulating state across container runs. Override EXTERNAL_SDKS_ROOT in production to a mounted volume if you want persistence.
+Rationale: a /tmp default avoids accumulating state across container runs.  
+Override EXTERNAL_SDKS_ROOT in production to a mounted volume if you want persistence.
 
 ---
 
 ## Architecture Overview
 
-- server.ts – Fastify app that exposes /sdk/upload and /run. Cleans EXTERNAL_SDKS_ROOT on startup.
-- names.ts – Sanitizes preferred SDK name and generates a unique folder name.
-- sdk-registry.ts – Discovers SDKs under EXTERNAL_SDKS_ROOT (index.ts/js) with a tiny TTL cache.
-- template.ts – Builds the entry source that imports SDKs and wires an axios-like HTTP bridge.
-- http-bridge.ts – Host-side HTTP bridge (axios-backed) used by the isolate to perform HTTP calls.
-- runner.ts – Bundles entry with esbuild and executes inside isolated-vm with memory/time limits.
-- esbuild-alias.ts – Maps axios and form-data to our shims when bundling user code.
-- startup.ts – Defensive cleanup of EXTERNAL_SDKS_ROOT contents.
-- config.ts – Centralized env config and defaults.
+- **server.ts** – Fastify app exposing `/sdk/upload`, `/sdk/docs/:namespace`, and `/run`.
+- **names.ts** – Sanitizes preferred SDK names and ensures unique folder creation.
+- **sdk-registry.ts** – Discovers SDKs under EXTERNAL_SDKS_ROOT with a TTL cache.
+- **template.ts** – Builds entry source importing SDKs and wiring axios bridge.
+- **http-bridge.ts** – Host-side HTTP bridge (axios-backed) used by the isolate.
+- **runner.ts** – Bundles and executes code in isolated-vm with strict limits.
+- **esbuild-alias.ts** – Maps axios and form-data to shims when bundling user code.
+- **startup.ts** – Cleans EXTERNAL_SDKS_ROOT on startup.
+- **config.ts** – Centralized environment config and defaults.
 
-Key flows:
-1) /sdk/upload saves the spec, runs codegen, ensures index.ts exists, and invalidates discovery cache.
-2) /run discovers SDKs (cached), generates entry code, bundles with esbuild, runs inside isolated-vm, returns value and logs.
+**Key flows:**
+1. `/sdk/upload` saves the spec, runs OpenAPI Generator (`typescript-axios`), ensures an index export, and invalidates the cache.
+2. `/sdk/docs/:namespace` runs OpenAPI Generator’s `markdown` generator to produce SDK documentation and returns all `.md` files in JSON form.
+3. `/run` discovers SDKs, generates entry code, bundles with esbuild, executes in an isolate, and returns results.
 
 ---
 
 ## Testing
 
-We use Vitest. Tests live in test/ outside the src/ tree and run quickly.
+We use Vitest. Tests live in `test/` outside the `src/` tree.
 
-- Unit tests: template, http-bridge, names, sdk-registry, runner.
-- Integration test: boots the service, uploads a small spec, starts a mock API, executes a snippet using the generated SDK.
+- **Unit tests:** template, http-bridge, names, sdk-registry, runner.
+- **Integration tests:** verify spec upload, SDK generation, documentation generation, and snippet execution.
 
 Run:
 
 ```bash
 pnpm test
 ```
-
-Tips:
-- The isolated-vm and esbuild dependencies are mocked in unit tests for speed and determinism.
-- The http-bridge exposes a `__HTTP_BRIDGE_REQUEST_STUB__` hook for tests to intercept requests without network (a legacy alias `__AXIOS_REQUEST_STUB__` is still accepted).
 
 ---
 
@@ -137,7 +198,7 @@ Tips:
 - Coding style: TypeScript, ESM, Prettier + ESLint (see repo root).
 - Use file-level TSDoc to document module purpose; prefer small, single-responsibility modules.
 - Keep tests fast and focused; integration tests should remain minimal and hermetic.
-- Prefer explicit imports with .js extensions for local ESM files inside src/.
+- Prefer explicit imports with `.js` extensions for local ESM files inside `src/`.
 - When changing public behavior, update this README and relevant tests.
 
 To run only this package's tests:
@@ -154,9 +215,3 @@ pnpm test
 - Snippets run in an isolate with Node internals like fs, net, child_process, etc., excluded from the bundle.
 - Network access happens only through the host-side bridge; consider adding allowlists/ratelimiting for production.
 - Add authentication/authorization around the endpoints for multi-tenant deployments.
-
----
-
-## License
-
-MIT

--- a/src/typescript-runtime/openapitools.json
+++ b/src/typescript-runtime/openapitools.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.16.0"
+  }
+}

--- a/src/typescript-runtime/package.json
+++ b/src/typescript-runtime/package.json
@@ -25,18 +25,18 @@
     "fastify": "^4.28.1",
     "form-data": "^4.0.4",
     "isolated-vm": "^5.0.2",
-    "openapi-typescript-codegen": "^0.29.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@openapitools/openapi-generator-cli": "^2.13.1",
     "@types/node": "^20.14.10",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
+    "@vitest/coverage-v8": "^2.1.1",
     "eslint": "^9.9.0",
     "prettier": "^3.3.3",
     "tsx": "^4.16.2",
     "typescript": "^5.6.2",
-    "vitest": "^2.1.1",
-    "@vitest/coverage-v8": "^2.1.1"
+    "vitest": "^2.1.1"
   }
 }

--- a/src/typescript-runtime/src/lib/openapi-gen.ts
+++ b/src/typescript-runtime/src/lib/openapi-gen.ts
@@ -1,0 +1,14 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+const execFileAsync = promisify(execFile);
+
+export async function runOpenApiGenerator(args: string[], cwd?: string) {
+    // Uses the local node_modules binary
+    const bin = process.platform === "win32"
+        ? "npx.cmd"
+        : "npx";
+
+    const fullArgs = ["@openapitools/openapi-generator-cli", "generate", ...args];
+    const { stdout, stderr } = await execFileAsync(bin, fullArgs, { cwd });
+    return { stdout, stderr };
+}


### PR DESCRIPTION
### Summary
This PR raises the quality and reliability of the `com.gentorox.services.knowledgebase` package by introducing consistent SLF4J logging, comprehensive Javadoc, safer I/O and initialization paths, and a clearer persistence story for the knowledge base state. It also formalizes the OpenAPI specs directory and strengthens Spring configuration validation.

### Motivation and Context
- Improve maintainability and readability through clear naming, Javadoc, and consistent logging conventions.
- Reduce operational risk by avoiding swallowed exceptions and by creating backups when persisting state.
- Speed up startup with a compact, cached `KnowledgeBaseState` and clear cache restoration semantics.
- Provide predictable configuration and initialization behavior in Spring contexts.

### What’s Changed
- Logging and conventions
  - Replace `LOG` with `LOGGER` and use SLF4J consistently across the package.
  - Add contextual `debug/info/warn/error` logs for load/save, directory traversal, OpenAPI processing, and error paths.
- Documentation and API hygiene
  - Add Javadoc for public interfaces, classes, and methods: `KnowledgeBaseService`, `KnowledgeBaseServiceImpl`, `KnowledgeBasePersistence`, `FileKnowledgeBasePersistence`, `KnowledgeBaseEntry`, `KnowledgeBaseState`.
  - Enforce null-safety using `Objects.requireNonNull` for critical inputs.
- Persistence (`FileKnowledgeBasePersistence`)
  - Rename `om` → `objectMapper` for clarity.
  - Pretty-printed JSON by default; ensure parent directories exist when saving.
  - Create timestamped `.bak.<epoch>` backups before overwriting existing state files.
  - Add logs for load/save operations and missing files.
- Service behavior (`KnowledgeBaseServiceImpl`)
  - Clearer constructor contract; default `stateFile` to `target/kb/knowledge-base-state.json` when not supplied.
  - Robust cache restore with signature check; avoid swallowing exceptions and log with context.
  - More defensive content resolution for `kb://`, `file://`, and `mem://` resources with debug logs.
  - Improve directory traversal resilience and logging across `docs/`, `tests/`, `feedback/`, and `openapi/`.
  - OpenAPI flow: log upload failures at error level; on failure, index raw spec and warn.
- Spring config (`KnowledgeBaseConfig`)
  - Validate foundation directory and throw `IllegalStateException` with a clear message if missing.
  - Create `state/` under the foundation root on first run; log initialization details and hint settings.

### Breaking Changes
- OpenAPI input directory standardized to `foundation/openapi` (was previously referred to as `specs` in places). Projects and tests should place OpenAPI specs under `openapi/`.

### Screenshots/Logs
- N/A (behavioral logs added; see `LOGGER` outputs during initialization, load/save, and OpenAPI processing).

### How to Test
1. Run unit tests:
   - `FileKnowledgeBasePersistenceTest`
   - `KnowledgeBaseServiceImplTest`
2. Manual smoke test:
   - Create a `foundation/` directory with `docs/`, `feedback/`, `tests/`, and `openapi/` (YAML/JSON specs) locally.
   - Start the application; verify logs show initialization, state directory creation, state file path, and any OpenAPI processing.
   - Confirm state file written to `<foundation>/state/knowledge-base-state.json` and a `.bak.<timestamp>` is created on subsequent runs.
   - Re-run without changes; verify `loadedFromCache()` becomes true (via logs or debugger) and no OpenAPI regeneration occurs.

### Checklist
- [x] Follows project naming and logging conventions (`LOGGER`, SLF4J levels)
- [x] Public APIs and classes documented with Javadoc
- [x] Null checks for public entry points and constructors
- [x] No exceptions swallowed silently; logs include context
- [x] Tests updated/verified and pass locally
- [x] Migration note included for OpenAPI directory location

### Related Issues
- Aligns with code review and quality improvements tracked for the knowledge base module

### Risk and Rollout
- Risk: Low to medium (touches initialization and persistence code paths)
- Rollout: Standard deployment
- Backout: Revert commit; old behavior remains compatible except for the `openapi/` directory location (restore prior location or adjust config/files accordingly)