### PR TITLE
fix(ci): use create-pull-request action instead of gh cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,26 +151,38 @@ jobs:
       run: |
         NEW_SNAPSHOT="${{ steps.calculate_version.outputs.new_snapshot }}"
         
-        # Create a new branch for version bump
-        BRANCH_NAME="release/bump-version-$NEW_SNAPSHOT"
-        git checkout -b "$BRANCH_NAME"
-        
         # Update version
         mvn -q -f src/mcpagent/pom.xml versions:set -DnewVersion="$NEW_SNAPSHOT" -DgenerateBackupPoms=false
         
-        # Commit and push to new branch
-        git add src/mcpagent/pom.xml
-        git commit -m "chore(release): bump version to $NEW_SNAPSHOT"
-        git push origin "$BRANCH_NAME"
-        
-        # Create PR using GitHub CLI
-        gh pr create \
-          --title "chore(release): bump version to $NEW_SNAPSHOT" \
-          --body "Automated version bump after release ${{ steps.calculate_version.outputs.version }}" \
-          --base main \
-          --head "$BRANCH_NAME"
-      env:
-        GH_TOKEN: ${{ github.token }}
+        echo "new_snapshot=$NEW_SNAPSHOT" >> $GITHUB_OUTPUT
+      id: version_bump
+    
+    - name: Create Pull Request for version bump
+      if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != true
+      uses: peter-evans/create-pull-request@v6
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "chore(release): bump version to ${{ steps.calculate_version.outputs.new_snapshot }}"
+        branch: release/bump-version-${{ steps.calculate_version.outputs.new_snapshot }}
+        delete-branch: true
+        title: "chore(release): bump version to ${{ steps.calculate_version.outputs.new_snapshot }}"
+        body: |
+          ## Automated version bump after release
+          
+          This PR bumps the version to `${{ steps.calculate_version.outputs.new_snapshot }}` following the release of `${{ steps.calculate_version.outputs.version }}`.
+          
+          ### Changes
+          - Updated `src/mcpagent/pom.xml` version to `${{ steps.calculate_version.outputs.new_snapshot }}`
+          
+          ### Release Information
+          - Released version: `${{ steps.calculate_version.outputs.version }}`
+          - Next development version: `${{ steps.calculate_version.outputs.new_snapshot }}`
+          
+          ---
+          
+          🤖 This PR was automatically created by the release workflow.
+        labels: release, automated
+        assignees: ${{ github.actor }}
     
     - name: Create GitHub Release
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
The gh CLI command was failing because GitHub Actions' default token is not permitted to create or approve pull requests.

Replace manual branch creation and gh pr create with the peter-evans/create-pull-request action which is designed to work with the default GITHUB_TOKEN without requiring additional permissions.

Benefits:
- Works with default GITHUB_TOKEN (no need for PAT or GitHub App)
- Automatically creates branch, commits changes, and opens PR
- Cleaner workflow with better error handling
- Adds labels and assignees automatically

### 🧾 Description

Please include a summary of the change and which issue is fixed.  
If this is a feature, explain the motivation and context.  
List any dependencies required for this change.

Fixes # (issue)

---

### ✅ Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work)
- [ ] 🧹 Refactor / Code style update
- [ ] 📄 Documentation update
- [ ] 🧪 Tests / CI improvement
- [ ] Other (please describe):

---

### 🧪 How Has This Been Tested?

Describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

---

### 📷 Screenshots (if applicable)

---

### 🧠 Checklist

- [ ] My code follows the project’s style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated documentation if necessary
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes  
